### PR TITLE
add secret resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.api</groupId>
+      <artifactId>com.ibm.websphere.appserver.api.passwordUtil</artifactId>
+      <version>1.0.58</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Dependencies for tests -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/io/openliberty/sample/secret/SecretResource.java
+++ b/src/main/java/io/openliberty/sample/secret/SecretResource.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+
+package io.openliberty.sample.secret;
+
+import com.ibm.websphere.crypto.PasswordUtil;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.core.MediaType;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@RequestScoped
+@Path("/secret")
+public class SecretResource {
+
+    private static final String SECRET_PHRASE_KEY = "io_openliberty_sample_secret_secretPhrase";
+    private static final String DEFAULT_SECRET_PHRASE = "defaultSecretPhrase";
+
+    @Inject
+    @ConfigProperty(name = SECRET_PHRASE_KEY, defaultValue = DEFAULT_SECRET_PHRASE)
+    private String encryptedSecretPhrase;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getSecretPhrase() {
+        if (DEFAULT_SECRET_PHRASE.equals(encryptedSecretPhrase)) {
+            String message = String.format("ERROR: The secret phrase was not set. [%s]", encryptedSecretPhrase);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message).build();
+        }
+        try {
+            String secretPhrase = PasswordUtil.decode(encryptedSecretPhrase);
+            String message = String.format("%s=%s", SECRET_PHRASE_KEY, secretPhrase);
+            return Response.ok(message).build();    
+        } catch (Exception e) {
+            String message = String.format("ERROR: Could not decrypt the secret phrase. [%s]", encryptedSecretPhrase);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message).build();
+        }
+    }
+
+}

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -6,6 +6,7 @@
     <feature>mpMetrics-5.0</feature>
     <feature>mpHealth-4.0</feature>
     <feature>mpConfig-3.0</feature>
+    <feature>passwordUtilities-1.1</feature>
   </featureManager>
 
   <applicationManager autoExpand="true" />


### PR DESCRIPTION
- add a new secret resource under `/system/secret`
    - the resource tries to inject the `io_openliberty_sample_secret_secretPhrase` property which has a default value of `defaultSecretPhrase`
    - the resource has a single endpoint `GET /system/secret`
    - the endpoint returns:
        - 500 and an error message if the property was not set
        - 500 and an error message if the property's value cannot be decrypted
        - 200 and the key and decrypted value otherwise